### PR TITLE
Add more style to trace logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/anchore/enterprise-client-go
 go 1.16
 
 require (
-	github.com/anchore/go-logger v0.0.0-20220519151928-4eea2d1fdacc
+	github.com/anchore/go-logger v0.0.0-20220615182446-aa2fd5fbd976
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/anchore/go-logger v0.0.0-20220519151928-4eea2d1fdacc h1:Dw1wvaQSnaZ/hBQ+YuKuUZg7E/ImQ9RxWf1oyOBvfHw=
 github.com/anchore/go-logger v0.0.0-20220519151928-4eea2d1fdacc/go.mod h1:wxBYJSK/RWDCQasMtzmGhRv7mLVF3Jx8O5z+oMtvrMQ=
+github.com/anchore/go-logger v0.0.0-20220615182446-aa2fd5fbd976 h1:FD9LBSJJmpbavMAkKkEUJRWbKtI2TYz0Z6oin2S17pQ=
+github.com/anchore/go-logger v0.0.0-20220615182446-aa2fd5fbd976/go.mod h1:wxBYJSK/RWDCQasMtzmGhRv7mLVF3Jx8O5z+oMtvrMQ=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/pkg/engine/client.go
+++ b/pkg/engine/client.go
@@ -34,6 +34,7 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/oauth2"
+	"github.com/anchore/go-logger"
 )
 
 var (
@@ -203,8 +204,8 @@ func parameterToJson(obj interface{}) (string, error) {
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Logger != nil && c.cfg.Debug {
-		c.cfg.Logger.Debugf("Request %s %s %s", request.Proto, request.Method, request.URL.Redacted())
-		c.cfg.Logger.WithFields("Accept", request.Header.Get("Accept"), "X-Anchore-Account", request.Header.Get("X-Anchore-Account")).Tracef("Headers: ")
+		c.cfg.Logger.Debugf("request %s %s %s", request.Proto, request.Method, request.URL.Redacted())
+		c.cfg.Logger.WithFields(getHeaderLogFields(request.Header)).Tracef("  ├── headers")
 		if request.Body != nil {
 			body, err := ioutil.ReadAll(request.Body)
             request.Body.Close()
@@ -213,12 +214,14 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 			}
 			pretty := &bytes.Buffer{}
 			json.Indent(pretty, body, "", "  ")
-			c.cfg.Logger.Tracef("Body: \n%s", pretty.String())
+			c.cfg.Logger.WithFields("length", pretty.Len()).Tracef("  └── body\n%s", pretty.String())
 
 			// reset read closer for body
 			reader := ioutil.NopCloser(bytes.NewReader(body))
 			request.Body = reader
-		}
+		} else {
+            c.cfg.Logger.WithFields("length", 0).Trace("  └── body")
+        }
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -227,8 +230,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	}
 
 	if c.cfg.Logger != nil && c.cfg.Debug {
-		c.cfg.Logger.Debugf("Response %s %s", resp.Proto, resp.Status)
-		c.cfg.Logger.WithFields("Content-Type", resp.Header.Get("Content-Type"), "Content-Length", resp.Header.Get("Content-Length"), "Date", resp.Header.Get("Date"), "Server", resp.Header.Get("Server")).Tracef("Headers: ")
+		c.cfg.Logger.Debugf("response %s %s", resp.Proto, resp.Status)
+		c.cfg.Logger.WithFields(getHeaderLogFields(resp.Header)).Tracef("  ├── headers")
 		if resp.Body != nil {
 			body, err := ioutil.ReadAll(resp.Body)
             resp.Body.Close()
@@ -237,14 +240,27 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 			}
 			pretty := &bytes.Buffer{}
 			json.Indent(pretty, body, "", "  ")
-			c.cfg.Logger.Tracef("Body: \n%s", pretty.String())
+			c.cfg.Logger.WithFields("length", pretty.Len()).Tracef("  └── body\n%s", pretty.String())
 
             // reset read closer for body
 			reader := ioutil.NopCloser(bytes.NewReader(body))
 			resp.Body = reader
-		}
+		} else {
+             c.cfg.Logger.WithFields("length", 0).Trace("  └── body")
+        }
 	}
 	return resp, err
+}
+
+func getHeaderLogFields(header http.Header) logger.Fields {
+	f := make(logger.Fields)
+	for k, vs := range header {
+		if strings.ToLower(k) == "authorization" {
+			continue
+		}
+		f[k] = "["+strings.Join(vs, ", ")+"]"
+	}
+	return f
 }
 
 // Allow modification of underlying config for alternate implementations and testing

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -28,6 +28,7 @@ import (
 	awsv4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
 	{{/withAWSV4Signature}}
+	"github.com/anchore/go-logger"
 )
 
 var (
@@ -167,8 +168,8 @@ func parameterToJson(obj interface{}) (string, error) {
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Logger != nil && c.cfg.Debug {
-		c.cfg.Logger.Debugf("Request %s %s %s", request.Proto, request.Method, request.URL.Redacted())
-		c.cfg.Logger.WithFields("Accept", request.Header.Get("Accept"), "X-Anchore-Account", request.Header.Get("X-Anchore-Account")).Tracef("Headers: ")
+		c.cfg.Logger.Debugf("request %s %s %s", request.Proto, request.Method, request.URL.Redacted())
+		c.cfg.Logger.WithFields(getHeaderLogFields(request.Header)).Tracef("  ├── headers")
 		if request.Body != nil {
 			body, err := ioutil.ReadAll(request.Body)
             request.Body.Close()
@@ -177,12 +178,14 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 			}
 			pretty := &bytes.Buffer{}
 			json.Indent(pretty, body, "", "  ")
-			c.cfg.Logger.Tracef("Body: \n%s", pretty.String())
+			c.cfg.Logger.WithFields("length", pretty.Len()).Tracef("  └── body\n%s", pretty.String())
 
 			// reset read closer for body
 			reader := ioutil.NopCloser(bytes.NewReader(body))
 			request.Body = reader
-		}
+		} else {
+            c.cfg.Logger.WithFields("length", 0).Trace("  └── body")
+        }
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -191,8 +194,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	}
 
 	if c.cfg.Logger != nil && c.cfg.Debug {
-		c.cfg.Logger.Debugf("Response %s %s", resp.Proto, resp.Status)
-		c.cfg.Logger.WithFields("Content-Type", resp.Header.Get("Content-Type"), "Content-Length", resp.Header.Get("Content-Length"), "Date", resp.Header.Get("Date"), "Server", resp.Header.Get("Server")).Tracef("Headers: ")
+		c.cfg.Logger.Debugf("response %s %s", resp.Proto, resp.Status)
+		c.cfg.Logger.WithFields(getHeaderLogFields(resp.Header)).Tracef("  ├── headers")
 		if resp.Body != nil {
 			body, err := ioutil.ReadAll(resp.Body)
             resp.Body.Close()
@@ -201,14 +204,27 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 			}
 			pretty := &bytes.Buffer{}
 			json.Indent(pretty, body, "", "  ")
-			c.cfg.Logger.Tracef("Body: \n%s", pretty.String())
+			c.cfg.Logger.WithFields("length", pretty.Len()).Tracef("  └── body\n%s", pretty.String())
 
             // reset read closer for body
 			reader := ioutil.NopCloser(bytes.NewReader(body))
 			resp.Body = reader
-		}
+		} else {
+             c.cfg.Logger.WithFields("length", 0).Trace("  └── body")
+        }
 	}
 	return resp, err
+}
+
+func getHeaderLogFields(header http.Header) logger.Fields {
+	f := make(logger.Fields)
+	for k, vs := range header {
+		if strings.ToLower(k) == "authorization" {
+			continue
+		}
+		f[k] = "["+strings.Join(vs, ", ")+"]"
+	}
+	return f
 }
 
 // Allow modification of underlying config for alternate implementations and testing


### PR DESCRIPTION
Move from this:
```
[0000] DEBUG Response HTTP/1.1 200 OK api=engine
[0000] TRACE Headers:  Content-Length=0 Content-Type= Date=Tue, 28 Jun 2022 20:54:13 GMT Server= api=engine
[0000] TRACE Body: 
{} api=engine
```
To this:
```
[0000] DEBUG response HTTP/1.1 200 OK api=engine
[0000] TRACE   ├── headers Content-Length=[0] Date=[Tue, 28 Jun 2022 21:02:02 GMT] api=engine
[0000] TRACE   └── body
{} api=engine length=0
```